### PR TITLE
Add input variable to action yml file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,9 @@
 name: 'Wait'
 description: 'Wait a designated number of milliseconds'
 inputs:
-  milliseconds:  # id of input
-    description: 'number of milliseconds to wait'
+  repo-token:
+    description: 'Token to use for API calls'
     required: true
-    default: '1000'
 outputs:
   time: # output will be available to future steps
     description: 'The current time after waiting'


### PR DESCRIPTION
@gusshawstewart 

The `repo-token` param you use in the [workflow](https://github.com/trojan-actions/test/blob/main/.github/workflows/blank.yml#L29) is not declared in the `action.yml` file.